### PR TITLE
ST-2811: Adding support for running as appuser in rhel image

### DIFF
--- a/kafka-rest/Dockerfile.rhel8
+++ b/kafka-rest/Dockerfile.rhel8
@@ -31,6 +31,7 @@ ENV COMPONENT=kafka-rest
 # default listener
 EXPOSE 8082
 
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -57,8 +58,11 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum clean all \
     && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
+    && chown appuser:appuser -R /etc/${COMPONENT} \
     && chmod -R ag+w /etc/${COMPONENT}
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]


### PR DESCRIPTION
The base image now has a user account "appuser" and this change will make the service run as that user instead of root.

The PR build for this will not succeed until the new version of the base image is published with the appuser.

I tested these changes by building the image and running cp-demo.