### PR TITLE
ST-2560: Adding labels required by RedHat container registry

### DIFF
--- a/kafka-rest/Dockerfile.deb8
+++ b/kafka-rest/Dockerfile.deb8
@@ -27,6 +27,8 @@ ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
 
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-rest-images"
+
 ENV COMPONENT=kafka-rest
 
 # default listener

--- a/kafka-rest/Dockerfile.rhel8
+++ b/kafka-rest/Dockerfile.rhel8
@@ -20,11 +20,19 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
+ARG GIT_COMMIT
 
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
+
 LABEL maintainer="partner-support@confluent.io"
+LABEL vendor="Confluent"
+LABEL version=$GIT_COMMIT
+LABEL release=$PROJECT_VERSION
+LABEL name=$ARTIFACT_ID
+LABEL summary="The Confluent REST Proxy provides a RESTful interface to a Kafka cluster, making it easy to produce and consume messages, view the state of the cluster, and perform administrative actions without using the native Kafka protocol or clients."
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-rest-images"
 
 ENV COMPONENT=kafka-rest
 


### PR DESCRIPTION
These labels are required to pass the RedHat certification process for uploading images to the container registry.