### PR TITLE
ST-3599: Remove show_env function because it exposes secrets

### DIFF
--- a/kafka-rest/include/etc/confluent/docker/run
+++ b/kafka-rest/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 


### PR DESCRIPTION
We don't want to print the environment variables in the logs during startup because they contain sensitive data.