### PR TITLE
ST-4240: remove yum update in non base Docker images

### DIFF
--- a/kafka-rest/Dockerfile.ubi8
+++ b/kafka-rest/Dockerfile.ubi8
@@ -42,7 +42,6 @@ EXPOSE 8082
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\


### PR DESCRIPTION
non base docker scripts that run yum update will cause issues because we rely on the base image's package versions, not the packages yup update fetches
