### PR TITLE
CLIENTS-1670: Unrequire ZOOKEEPER_CONNECT and HOST_NAME.

### DIFF
--- a/kafka-rest/include/etc/confluent/docker/configure
+++ b/kafka-rest/include/etc/confluent/docker/configure
@@ -16,8 +16,7 @@
 
 . /etc/confluent/docker/bash-config
 
-dub ensure-atleast-one KAFKA_REST_ZOOKEEPER_CONNECT KAFKA_REST_BOOTSTRAP_SERVERS
-dub ensure KAFKA_REST_HOST_NAME
+dub ensure KAFKA_REST_BOOTSTRAP_SERVERS
 
 dub path /etc/"${COMPONENT}"/ writable
 


### PR DESCRIPTION
ZOOKEEPER_CONNECT does not exist anymore in 6.0.0, and HOST_NAME is not really required (e.g. for V3 you should use ADVERTISED_LISTENERS instead).