### PR TITLE
Move slack build messages to #rest-proxy-warn.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ dockerfile {
     mvnPhase = 'package'
     mvnSkipDeploy = true
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
-    slackChannel = '#rest-proxy-eng'
+    slackChannel = '#rest-proxy-warn'
     upstreamProjects = []
     dockerPullDeps = ['confluentinc/cp-base-new']
     usePackages = true


### PR DESCRIPTION
We've been moving Slack notifications to the #rest-proxy-warn channel - see https://github.com/confluentinc/kafka-rest/pull/820 and https://github.com/confluentinc/ce-kafka-rest/pull/136.