### PR TITLE
build: Remove confluent yum/apt repo after installation

### DIFF
--- a/kafka-rest/Dockerfile.deb8
+++ b/kafka-rest/Dockerfile.deb8
@@ -37,16 +37,16 @@ EXPOSE 8082
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && apt-get install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..."  \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && chmod -R ag+w /etc/${COMPONENT}

--- a/kafka-rest/Dockerfile.ubi8
+++ b/kafka-rest/Dockerfile.ubi8
@@ -63,7 +63,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
         confluent-security-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && chown appuser:appuser -R /etc/${COMPONENT} \
     && chmod -R ag+w /etc/${COMPONENT}


### PR DESCRIPTION
Couple of changes:
* Remove confluent's repo config. Confluent's images don't need to be able to update to the next CP release (Customers should be consuming the next versioned docker release)
* Removed the AllowUnauthenticated piece: In practice, we always import the public key for GPG automation validation.
