### PR TITLE
KNET-12278 sign images and cherry pick service-bot change

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -121,7 +121,7 @@ blocks:
   - name: Deploy AMD confluentinc/cp-kafka-rest
     dependencies: ["Build, Test, & Scan AMD"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+'"
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       jobs:
         - name: Deploy AMD confluentinc/cp-kafka-rest ubi8
@@ -171,7 +171,7 @@ blocks:
   - name: Deploy ARM confluentinc/cp-kafka-rest
     dependencies: ["Build & Test ARM"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+'"
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       agent:
         machine:
@@ -195,7 +195,7 @@ blocks:
   - name: Create Manifest and Maven Deploy
     dependencies: ["Deploy AMD confluentinc/cp-kafka-rest", "Deploy ARM confluentinc/cp-kafka-rest"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+'"
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       jobs:
         - name: Create Manifest and Maven Deploy

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,106 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: kafka-rest-images
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/kafka-rest-images.git
+    run_on:
+    - branches
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+    whitelist:
+      branches:
+      - master
+      - main
+      - /^\d+\.\d+\.x$/
+      - /^\d+\.\d+\.\d+-cp\d+-rc\d+$/
+      - /^\d+\.\d+\.\d+-rc\d+$/
+      - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  tasks:
+  - name: cp-dockerfile-build
+    scheduled: False
+    branch: "master"
+    pipeline_file: .semaphore/cp_dockerfile_build.yml
+    parameters:
+    - name: CONFLUENT_VERSION
+      required: True
+      default_value: "NONE"
+      description: "Confluent Platform version."
+    - name: PACKAGES_URL
+      required: True
+      default_value: "NONE"
+      description: "S3 bucket url where the debian packages are located."
+    - name: PACKAGES_MAVEN_URL
+      required: True
+      default_value: "NONE"
+      description: "URL to Maven packages from upstream packaging job."
+    - name: PACKAGING_BUILD_NUMBER
+      required: True
+      default_value: "NONE"
+      description: "Build number of packaging job. Required except when doing promote to production. For promote to production only this will default to latest."
+    - name: ALLOW_UNSIGNED
+      required: True
+      default_value: "False"
+      description: "Allow unsigned packages."
+      options:
+       - True
+       - False
+    - name: CONFLUENT_DEB_VERSION
+      required: True
+      default_value: "1"
+      description: "Debian package version."
+  - name: cp-dockerfile-promote
+    scheduled: False
+    branch: "master"
+    pipeline_file: .semaphore/cp_dockerfile_promote.yml
+    parameters:
+    - name: CONFLUENT_VERSION
+      required: True
+      default_value: "NONE"
+      description: "Confluent Platform version."
+    - name: IMAGE_REVISION
+      required: True
+      default_value: "1"
+      description: "Revision for Docker images. This is used with promote to production only."
+    - name: UPDATE_LATEST_TAG
+      required: True
+      default_value: "NONE"
+      description: "Should the latest tag on docker hub be updated to point at this new image version."
+    - name: PACKAGING_BUILD_NUMBER
+      required: True
+      default_value: "NONE"
+      description: "Build number of packaging job. Required except when doing promote to production. For promote to production only this will default to latest."
+    - name: PROMOTE_OS_TYPE
+      required: True
+      default_value: "ubi"
+      description: "The image OS type to promote to DockerHub. Required only when doing promote to production."
+      options:
+       - deb
+       - ubi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,8 +33,11 @@ global_job_config:
       # For PR Builds using Packaging
       - pip install confluent-release-tools
       - if [ $BRANCH_TAG == "master" ]; then export BUILD_KEY=$(pinto get-master-version); else export BUILD_KEY=$BRANCH_TAG; fi
-      - export LATEST_PACKAGING_BUILD_NUMBER=$(aws s3 ls s3://jenkins-confluent-packages/$BRANCH_TAG/ --no-paginate --recursive | grep "$BRANCH_TAG/[0-9]" | sort | tail -n 1 | awk '{print $4}' | awk -F
-        / '{print $2}')
+      - export PACKAGING_BUCKET="s3://jenkins-confluent-packages/$BRANCH_TAG/"
+      - export LATEST_PACKAGING_BUILD_NUMBER=$(aws s3 ls $PACKAGING_BUCKET --no-paginate | grep 'PRE' | awk '{print $NF}' | awk '{print substr($1, 1, length($1)-1)}' | sort -n | tail -n 1)
+      # Check if version is complete, otherwise use the previous version
+      - (aws s3 ls $PACKAGING_BUCKET$LATEST_PACKAGING_BUILD_NUMBER/deb/ && aws s3 ls $PACKAGING_BUCKET$LATEST_PACKAGING_BUILD_NUMBER/rpm/ && aws s3 ls $PACKAGING_BUCKET$LATEST_PACKAGING_BUILD_NUMBER/archive/)
+        || export LATEST_PACKAGING_BUILD_NUMBER=$(aws s3 ls $PACKAGING_BUCKET --no-paginate | grep 'PRE' | awk '{print $NF}' | awk '{print substr($1, 1, length($1)-1)}' | sort -n | tail -n 2 | head -n 1)
       - export CONFLUENT_VERSION=$(pinto get-version --build $BUILD_KEY --key confluent.version)
       - export DEFAULT_OS_TYPE="ubi"
       - export URL_CONFLUENT_VERSION=$(echo $CONFLUENT_VERSION | awk -F . '{print $1"."$2}')

--- a/service.yml
+++ b/service.yml
@@ -15,7 +15,7 @@ semaphore:
   nano_version: true
   build_arm: true
   cve_scan: true
-  sign_image: true
+  sign_images: true
   use_packages: true
   cp_images: true
   tasks:


### PR DESCRIPTION
This PR fix `sign_images` param (was `sign_image` previously), and cherry-pick the [change](https://github.com/confluentinc/kafka-rest-images/commit/f7adfe81ebb22049e805ef9c70b8b74480061dd6) from cc-service-bot that doesn't skip deploy phase.