### PR TITLE
Fix sign_images parameter was wrongly specified

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -15,7 +15,7 @@ semaphore:
   nano_version: true
   build_arm: true
   cve_scan: true
-  sign_image: true
+  sign_images: true
   use_packages: true
   cp_images: true
   tasks:


### PR DESCRIPTION
`sign_images` parameter was wrongly named (typo, missing an `s` at the end)