### PR TITLE
CPBR-3547: Migrate cp-kafka-rest to UBI9 micro base image

### DIFF
--- a/kafka-rest/Dockerfile.ubi9
+++ b/kafka-rest/Dockerfile.ubi9
@@ -15,8 +15,52 @@
 
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=ubi9-latest
+ARG UBI9_VERSION
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java:${DOCKER_UPSTREAM_TAG}
+# Stage 1: Get package_dedupe tool from base image
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG} AS tools
+
+# Stage 2: Install packages using ubi9 with dnf to /microdir
+FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
+
+ARG BUILD_NUMBER=-1
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+RUN echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && mkdir -p /microdir
+
+COPY --from=tools /usr/bin/package_dedupe /usr/local/bin/package_dedupe
+
+RUN echo "===> Installing confluent-kafka-rest, confluent-telemetry, confluent-security ..." \
+    && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
+       confluent-kafka-rest-${CONFLUENT_VERSION} \
+       confluent-telemetry-${CONFLUENT_VERSION} \
+       confluent-security-${CONFLUENT_VERSION} \
+    && echo "===> Deduping jars in /microdir ..." \
+    && package_dedupe /microdir/usr/share/java \
+    && echo "===> Cleaning up ..." \
+    && dnf --installroot=/microdir clean all \
+    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* \
+    && rm -rf /etc/yum.repos.d/confluent.repo \
+    && echo "===> Removing user database files to preserve base image's appuser ..." \
+    && rm -f /microdir/etc/passwd /microdir/etc/group /microdir/etc/shadow /microdir/etc/gshadow \
+             /microdir/etc/subuid /microdir/etc/subgid \
+    && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
+
+# Stage 3: Final image using cp-base-java-micro
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-java-micro:${DOCKER_UPSTREAM_TAG}
 
 # default listener
 EXPOSE 8082
@@ -40,39 +84,25 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.repo="confluentinc/kafka-rest-images"
 
-ARG CONFLUENT_VERSION
-ARG CONFLUENT_PACKAGES_REPO
-ARG CONFLUENT_PLATFORM_LABEL
-
 USER root
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && microdnf install -y \
-        confluent-${COMPONENT}-${CONFLUENT_VERSION} \
-        # We are installing confluent-telemetry package explicitly because
-        # Rest proxy's deb/rpm packages cannot directly depend on
-        # confluent-telemetry package as Rest proxy is Open Source.
-        confluent-telemetry-${CONFLUENT_VERSION} \
-        confluent-security-${CONFLUENT_VERSION} \
-    && echo "===> Deduping jars present in /usr/share/java ..." \
-    && package_dedupe /usr/share/java \
-    && echo "===> clean up ..."  \
-    && microdnf clean all \
-    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
-    && echo "===> Setting up ${COMPONENT} dirs" \
-    && chown appuser:root -R /etc/${COMPONENT} \
+COPY --from=builder /microdir/usr/bin/kafka-rest-run-class /usr/bin/
+COPY --from=builder /microdir/usr/bin/kafka-rest-start /usr/bin/
+COPY --from=builder /microdir/usr/bin/kafka-rest-stop /usr/bin/
+COPY --from=builder /microdir/usr/bin/kafka-rest-stop-service /usr/bin/
+COPY --from=builder /microdir/usr/bin/security-plugins-run-class /usr/bin/
+COPY --from=builder /microdir/usr/bin/sr-acl-cli /usr/bin/
+COPY --from=builder /microdir/usr/share/java /usr/share/java
+COPY --from=builder /microdir/usr/share/doc /usr/share/doc
+COPY --from=builder /microdir/etc/kafka-rest /etc/kafka-rest
+
+COPY include/etc/confluent/docker/ /etc/confluent/docker/
+RUN chown -R ${APP_UID}:${APP_GID} /etc/confluent/docker
+
+RUN echo "===> Setting up ${COMPONENT} dirs ..." \
+    && chown ${APP_UID}:root -R /etc/${COMPONENT} \
     && chmod -R ug+w /etc/${COMPONENT}
 
-COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
-
-USER appuser
+USER ${APP_UID}
 
 CMD ["/etc/confluent/docker/run"]

--- a/kafka-rest/Dockerfile.ubi9
+++ b/kafka-rest/Dockerfile.ubi9
@@ -89,10 +89,7 @@ LABEL io.confluent.docker.git.repo="confluentinc/kafka-rest-images"
 
 USER root
 
-COPY --from=builder /microdir/usr/bin/kafka-rest-run-class /usr/bin/
-COPY --from=builder /microdir/usr/bin/kafka-rest-start /usr/bin/
-COPY --from=builder /microdir/usr/bin/kafka-rest-stop /usr/bin/
-COPY --from=builder /microdir/usr/bin/kafka-rest-stop-service /usr/bin/
+COPY --from=builder /microdir/usr/bin/kafka-rest-* /usr/bin/
 COPY --from=builder /microdir/usr/bin/security-plugins-run-class /usr/bin/
 COPY --from=builder /microdir/usr/bin/sr-acl-cli /usr/bin/
 COPY --from=builder /microdir/usr/share/java /usr/share/java

--- a/kafka-rest/Dockerfile.ubi9
+++ b/kafka-rest/Dockerfile.ubi9
@@ -46,6 +46,9 @@ COPY --from=tools /usr/bin/package_dedupe /usr/local/bin/package_dedupe
 RUN echo "===> Installing confluent-kafka-rest, confluent-telemetry, confluent-security ..." \
     && dnf install -y --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs \
        confluent-kafka-rest-${CONFLUENT_VERSION} \
+       # We are installing confluent-telemetry package explicitly because
+       # Rest proxy's deb/rpm packages cannot directly depend on
+       # confluent-telemetry package as Rest proxy is Open Source.
        confluent-telemetry-${CONFLUENT_VERSION} \
        confluent-security-${CONFLUENT_VERSION} \
     && echo "===> Deduping jars in /microdir ..." \

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -55,6 +55,32 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                    </buildArgs>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/kafka-rest/pom.xml
+++ b/kafka-rest/pom.xml
@@ -57,16 +57,6 @@
             </plugin>
 
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <configuration>
-                    <buildArgs>
-                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
-                    </buildArgs>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
## Summary

Migrates **cp-kafka-rest** Docker image from the to ubi9 micro base. 

More details at: https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/4381213566/Distroless+and+Ubi9+micro+estimations

## Testing
Tested images: 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/dev/confluentinc/cp-kafka-rest:dev-8.3.x-b9ae9beb-ubi9.amd64 via the latest PR CI build: https://semaphore.ci.confluent.io/workflows/b9ae9beb-b96b-4f3a-9a99-92aa7a110494?pipeline_id=16d089f8-0894-440c-adcb-1eb14e4f9b4f


CFK e2e tests (`[e2e-plaintext-kraft](https://confluentinc.atlassian.net/browse/E2E-plaintext-kraft)`) ran on KinD with the dev micro-migrated `cp-kafka-rest` image overriding the prod baseline — all tests passed:

<img width="1575" height="948" alt="image" src="https://github.com/user-attachments/assets/09f07575-7d70-4b98-aaa2-d4d5f569a394" />

<img width="1575" height="948" alt="image" src="https://github.com/user-attachments/assets/d18ebb2c-9fb8-40bd-ac6b-3e90f1a87e13" />


Local redhat certification of cp-kafka-rest is passing:
https://semaphore.ci.confluent.io/workflows/d9c8d552-3b25-4bbe-a331-6ce4431a0b69


CFK e2e tests will be run post merging this PR. Ref: https://confluentinc.atlassian.net/wiki/spaces/CLUSTER/pages/4838985855/Self-Service+CFK+E2E+Testing+-+User+Manual