### PR TITLE
[CPBR-3661] Add s390x service.yml config for kafka-rest-images

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -92,8 +92,11 @@ global_job_config:
       - export DOCKER_UPSTREAM_TAG="$LATEST_TAG"
       - export DOCKER_REPOS="confluentinc/cp-kafka-rest"
       - export COMMUNITY_DOCKER_REPOS=""
+      - export S390X_DOCKER_REPOS="confluentinc/cp-kafka-rest"
+      - export S390X_MAVEN_MODULES="kafka-rest"
       - |
         export COMMUNITY_MVN_PL_ARGS=""
+        export S390X_MVN_PL_ARGS="-pl ${S390X_MAVEN_MODULES// /,} -am"
         if [[ $SKIP_COMMUNITY == "True" ]]; then
           # Filter out community repos from DOCKER_REPOS
           DOCKER_REPOS=$(comm -23 <(echo "$DOCKER_REPOS" | tr ' ' '\n' | sort) <(echo "$COMMUNITY_DOCKER_REPOS" | tr ' ' '\n' | sort) | tr '\n' ' ' | xargs)
@@ -108,10 +111,15 @@ global_job_config:
               return 130
             fi
           done
+
+          S390X_DOCKER_REPOS=$(comm -23 <(echo "$S390X_DOCKER_REPOS" | tr ' ' '\n' | sort) <(echo "$COMMUNITY_DOCKER_REPOS" | tr ' ' '\n' | sort) | tr '\n' ' ' | xargs)
+          export S390X_DOCKER_REPOS
+          echo "S390X_DOCKER_REPOS after skipping community images - $S390X_DOCKER_REPOS"
         fi
       - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$BUILD_NUMBER"
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
+      - export S390X_ARCH=.s390x
 blocks:
   - name: Validation
     dependencies: []
@@ -248,8 +256,66 @@ blocks:
             - export LATEST_PUSH_TAG=$LATEST_TAG$OS_TAG$ARM_ARCH
             - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
             - docker push $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
+  - name: Build & Test s390x
+    dependencies: ["Validation"]
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '/.github/', '/service.yml', '/README.md'], default_branch: 'master'})"
+    task:
+      jobs:
+        - name: Build & Test s390x ubi9
+          commands:
+            - export OS_TAG="-ubi9"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - ci-tools ci-update-version --direct-pom-edit
+            - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
+            - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
+            # Register QEMU binfmt for s390x so Docker can run s390x containers on amd64 for testing.
+            # ARM builds run on native arm64 machines, but s390x cross-compiles on amd64 via BuildX and needs QEMU.
+            - docker run --privileged --rm tonistiigi/binfmt --install s390x
+            - 'docker buildx ls | grep -q s390x || (echo "ERROR: s390x binfmt registration failed" && exit 1)'
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U $S390X_MVN_PL_ARGS -Ddocker.registry=$DOCKER_DEV_REGISTRY 
+              -Ddocker.upstream-registry=$DOCKER_UPSTREAM_REGISTRY -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$S390X_ARCH 
+              -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG -Darch.type=$S390X_ARCH -Ddocker.os_type=ubi9 -Ddocker.buildx.platforms=linux/s390x $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true
+            - . cache-maven store
+            - export S390X_DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${S390X_DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
+            - export S390X_DOCKER_DEV_FULL_IMAGES=${S390X_DOCKER_DEV_FULL_IMAGES// /$S390X_ARCH }$S390X_ARCH
+            - for image in $S390X_DOCKER_DEV_FULL_IMAGES; do echo "Pushing $image" && docker push $image; done
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+            - artifact push workflow target --destination target-S390X
+  - name: Deploy s390x confluentinc/cp-kafka-rest
+    dependencies: ["Build & Test s390x"]
+    run:
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
+    task:
+      jobs:
+        - name: Deploy s390x confluentinc/cp-kafka-rest ubi9
+          commands:
+            - export OS_TAG="-ubi9"
+            - export PROD_IMAGE_NAME=${DOCKER_PROD_REGISTRY}confluentinc/cp-kafka-rest
+            - export GIT_COMMIT_TAG=$GIT_COMMIT$OS_TAG$S390X_ARCH
+            - export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG$S390X_ARCH
+            - export DEV_IMAGE_FULL=${DOCKER_DEV_REGISTRY}confluentinc/cp-kafka-rest:$DOCKER_DEV_TAG$OS_TAG$S390X_ARCH
+            - docker pull $DEV_IMAGE_FULL
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - docker push $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - docker push $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - sign-images $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - sign-images $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$S390X_ARCH
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - docker push $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - sign-images $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - export LATEST_PUSH_TAG=$LATEST_TAG$OS_TAG$S390X_ARCH
+            - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
+            - docker push $PROD_IMAGE_NAME:$LATEST_PUSH_TAG
   - name: Create Manifest and Maven Deploy
-    dependencies: ["Deploy AMD confluentinc/cp-kafka-rest", "Deploy ARM confluentinc/cp-kafka-rest"]
+    dependencies: ["Deploy AMD confluentinc/cp-kafka-rest", "Deploy ARM confluentinc/cp-kafka-rest", "Deploy s390x confluentinc/cp-kafka-rest"]
     run:
       when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?(-rc[0-9]+)?$'"
     task:
@@ -275,21 +341,25 @@ blocks:
               for image in $DOCKER_PROD_IMAGE_NAME;
               do
                 export OS_TAG="-ubi9"
+                # Check if current image has an s390x build. ${IS_S390X:+...} conditionally
+                # includes the s390x digest in the manifest only for repos in S390X_DOCKER_REPOS.
+                IS_S390X=""
+                for s390x_repo in $S390X_DOCKER_REPOS; do if [[ "$image" == "$DOCKER_PROD_REGISTRY$s390x_repo" ]]; then IS_S390X="true"; break; fi; done
                 export GIT_TAG=$GIT_COMMIT$OS_TAG
-                docker manifest create $image:$GIT_TAG $image:$GIT_TAG$AMD_ARCH $image:$GIT_TAG$ARM_ARCH
+                docker manifest create $image:$GIT_TAG $image:$GIT_TAG$AMD_ARCH $image:$GIT_TAG$ARM_ARCH ${IS_S390X:+$image:$GIT_TAG$S390X_ARCH}
                 docker manifest push $image:$GIT_TAG
                 docker pull $image:$GIT_TAG
                 sign-images $image:$GIT_TAG
                 export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG
-                docker manifest create $image:$BRANCH_BUILD_TAG $image:$BRANCH_BUILD_TAG$AMD_ARCH $image:$BRANCH_BUILD_TAG$ARM_ARCH
+                docker manifest create $image:$BRANCH_BUILD_TAG $image:$BRANCH_BUILD_TAG$AMD_ARCH $image:$BRANCH_BUILD_TAG$ARM_ARCH ${IS_S390X:+$image:$BRANCH_BUILD_TAG$S390X_ARCH}
                 docker manifest push $image:$BRANCH_BUILD_TAG
                 docker pull $image:$BRANCH_BUILD_TAG
                 sign-images $image:$BRANCH_BUILD_TAG
                 export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG
-                docker manifest create $image:$PACKAGE_TAG $image:$PACKAGE_TAG$AMD_ARCH $image:$PACKAGE_TAG$ARM_ARCH
+                docker manifest create $image:$PACKAGE_TAG $image:$PACKAGE_TAG$AMD_ARCH $image:$PACKAGE_TAG$ARM_ARCH ${IS_S390X:+$image:$PACKAGE_TAG$S390X_ARCH}
                 docker manifest push $image:$PACKAGE_TAG
                 export LATEST_MANIFEST_TAG=$LATEST_TAG$OS_TAG
-                docker manifest create $image:$LATEST_MANIFEST_TAG $image:$LATEST_MANIFEST_TAG$AMD_ARCH $image:$LATEST_MANIFEST_TAG$ARM_ARCH
+                docker manifest create $image:$LATEST_MANIFEST_TAG $image:$LATEST_MANIFEST_TAG$AMD_ARCH $image:$LATEST_MANIFEST_TAG$ARM_ARCH ${IS_S390X:+$image:$LATEST_MANIFEST_TAG$S390X_ARCH}
                 docker manifest push $image:$LATEST_MANIFEST_TAG
               done
 after_pipeline:
@@ -309,4 +379,5 @@ after_pipeline:
           - checkout
           - artifact pull workflow target-AMD
           - artifact pull workflow target-ARM
+          - artifact pull workflow target-S390X
           - emit-sonarqube-data --run_only_sonar_scan

--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -48,6 +48,7 @@ global_job_config:
       - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
+      - export S390X_ARCH=.s390x
       - export COMMUNITY_DOCKER_REPOS=""
       - |
         if [[ $SKIP_COMMUNITY == "True" ]]; then
@@ -132,8 +133,44 @@ blocks:
                   docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
                   docker push $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
               fi
+
+  - name: Promote s390x
+    dependencies: []
+    task:
+      jobs:
+        - name: Promote confluentinc/cp-kafka-rest ubi9 s390x
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/cp-kafka-rest
+          commands:
+            - export OS_TYPE="ubi9"
+            - export DOCKER_REPO="confluentinc/cp-kafka-rest"
+            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$S390X_ARCH"
+            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$S390X_ARCH"
+            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
+            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
+            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
+            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
+            - docker push $DOCKER_REPO:$PROMOTED_TAG
+            - >-
+              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+                  export APPLY_TAG=$CONFLUENT_VERSION$S390X_ARCH
+                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
+                  docker push $DOCKER_REPO:$APPLY_TAG
+                  export APPLIED="true"
+              fi
+            - >-
+              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+                  if [[ $APPLIED ]]; then
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$S390X_ARCH
+                  docker push $DOCKER_REPO:latest$S390X_ARCH
+                  fi
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
+                  docker push $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
+              fi
   - name: Create Manifest
-    dependencies: ["Promote AMD", "Promote ARM"]
+    dependencies: ["Promote AMD", "Promote ARM", "Promote s390x"]
     task:
       jobs:
         - name: Create Manifest confluentinc/cp-kafka-rest ubi9
@@ -145,20 +182,20 @@ blocks:
             - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
             - export DOCKER_REPO="confluentinc/cp-kafka-rest"
             - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"
-            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH
+            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH $DOCKER_REPO:$PROMOTED_TAG$S390X_ARCH
             - docker manifest push $DOCKER_REPO:$PROMOTED_TAG
             - >-
               if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
-                  docker manifest create $DOCKER_REPO:$CONFLUENT_VERSION $DOCKER_REPO:$CONFLUENT_VERSION$AMD_ARCH $DOCKER_REPO:$CONFLUENT_VERSION$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:$CONFLUENT_VERSION $DOCKER_REPO:$CONFLUENT_VERSION$AMD_ARCH $DOCKER_REPO:$CONFLUENT_VERSION$ARM_ARCH $DOCKER_REPO:$CONFLUENT_VERSION$S390X_ARCH
                   docker manifest push $DOCKER_REPO:$CONFLUENT_VERSION
                   export APPLIED="true"
               fi
             - >-
               if [[ $UPDATE_LATEST_TAG == "True" ]]; then
                   if [[ $APPLIED ]]; then
-                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH $DOCKER_REPO:latest$S390X_ARCH
                   docker manifest push $DOCKER_REPO:latest
                   fi
-                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH $DOCKER_REPO:latest-$OS_TYPE$S390X_ARCH
                   docker manifest push $DOCKER_REPO:latest-$OS_TYPE
               fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -85,8 +85,11 @@ global_job_config:
       - export DOCKER_UPSTREAM_TAG="$LATEST_TAG"
       - export DOCKER_REPOS="confluentinc/cp-kafka-rest"
       - export COMMUNITY_DOCKER_REPOS=""
+      - export S390X_DOCKER_REPOS="confluentinc/cp-kafka-rest"
+      - export S390X_MAVEN_MODULES="kafka-rest"
       - |
         export COMMUNITY_MVN_PL_ARGS=""
+        export S390X_MVN_PL_ARGS="-pl ${S390X_MAVEN_MODULES// /,} -am"
         if [[ $SKIP_COMMUNITY == "True" ]]; then
           # Filter out community repos from DOCKER_REPOS
           DOCKER_REPOS=$(comm -23 <(echo "$DOCKER_REPOS" | tr ' ' '\n' | sort) <(echo "$COMMUNITY_DOCKER_REPOS" | tr ' ' '\n' | sort) | tr '\n' ' ' | xargs)
@@ -101,10 +104,15 @@ global_job_config:
               return 130
             fi
           done
+
+          S390X_DOCKER_REPOS=$(comm -23 <(echo "$S390X_DOCKER_REPOS" | tr ' ' '\n' | sort) <(echo "$COMMUNITY_DOCKER_REPOS" | tr ' ' '\n' | sort) | tr '\n' ' ' | xargs)
+          export S390X_DOCKER_REPOS
+          echo "S390X_DOCKER_REPOS after skipping community images - $S390X_DOCKER_REPOS"
         fi
       - export DOCKER_DEV_TAG="dev-$BRANCH_TAG-$BUILD_NUMBER"
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
+      - export S390X_ARCH=.s390x
 blocks:
   - name: Validation
     dependencies: []
@@ -176,6 +184,36 @@ blocks:
             - . publish-test-results
             - artifact push workflow target/test-results
             - artifact push workflow target --destination target-ARM
+  - name: Build & Test s390x
+    dependencies: ["Validation"]
+    run:
+      when: "pull_request =~ '.*'"
+    task:
+      jobs:
+        - name: Build & Test s390x ubi9
+          commands:
+            - export OS_TAG="-ubi9"
+            - export DOCKER_UPSTREAM_TAG="${DOCKER_UPSTREAM_TAG}${OS_TAG}"
+            - ci-tools ci-update-version --direct-pom-edit
+            - export OS_PACKAGES_URL=$(echo "$PACKAGES_URL" | sed "s/PACKAGE_TYPE/rpm/g")
+            - export PACKAGING_BUILD_ARGS="$PACKAGING_BUILD_ARGS -DCONFLUENT_PACKAGES_REPO=$OS_PACKAGES_URL"
+            # Register QEMU binfmt for s390x so Docker can run s390x containers on amd64 for testing.
+            # ARM builds run on native arm64 machines, but s390x cross-compiles on amd64 via BuildX and needs QEMU.
+            - docker run --privileged --rm tonistiigi/binfmt --install s390x
+            - 'docker buildx ls | grep -q s390x || (echo "ERROR: s390x binfmt registration failed" && exit 1)'
+            - mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean package dependency:analyze validate -U $S390X_MVN_PL_ARGS -Ddocker.registry=$DOCKER_DEV_REGISTRY 
+              -Ddocker.upstream-registry=$DOCKER_UPSTREAM_REGISTRY -DBUILD_NUMBER=$BUILD_NUMBER -DGIT_COMMIT=$GIT_COMMIT -Ddocker.tag=$DOCKER_DEV_TAG$OS_TAG$S390X_ARCH 
+              -Ddocker.upstream-tag=$DOCKER_UPSTREAM_TAG -Darch.type=$S390X_ARCH -Ddocker.os_type=ubi9 -Ddocker.buildx.platforms=linux/s390x $PACKAGING_BUILD_ARGS -Ddependency.check.skip=true
+            - . cache-maven store
+            - export S390X_DOCKER_DEV_FULL_IMAGES=$DOCKER_DEV_REGISTRY${S390X_DOCKER_REPOS// /:$DOCKER_DEV_TAG$OS_TAG $DOCKER_DEV_REGISTRY}:$DOCKER_DEV_TAG$OS_TAG
+            - export S390X_DOCKER_DEV_FULL_IMAGES=${S390X_DOCKER_DEV_FULL_IMAGES// /$S390X_ARCH }$S390X_ARCH
+            - for image in $S390X_DOCKER_DEV_FULL_IMAGES; do echo "Pushing $image" && docker push $image; done
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+            - artifact push workflow target --destination target-S390X
 after_pipeline:
   task:
     agent:
@@ -193,4 +231,5 @@ after_pipeline:
           - checkout
           - artifact pull workflow target-AMD
           - artifact pull workflow target-ARM
+          - artifact pull workflow target-S390X
           - emit-sonarqube-data --run_only_sonar_scan

--- a/service.yml
+++ b/service.yml
@@ -94,6 +94,9 @@ semaphore:
         options:
           - 'True'
           - 'False'
+cp_dockerfile:
+  s390x_docker_repos: ['confluentinc/cp-kafka-rest']
+  s390x_maven_modules: ['kafka-rest']
 code_artifact:
   enable: true
   package_paths:


### PR DESCRIPTION
## Summary
- Adds `cp_dockerfile` block to `service.yml` with `s390x_docker_repos` and `s390x_maven_modules` for s390x image builds

## Context
Follow-up to https://github.com/confluentinc/kafka-rest-images/pull/146 which targeted `8.2.x`. This PR applies the `service.yml` changes directly to `master` to avoid merge conflicts from pint-merge.

## Test plan
- [ ] Verify cc-service-bot generates correct s390x semaphore pipeline blocks from the new service.yml config
- [ ] Validate s390x build pipeline triggers correctly on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)