### PR TITLE
CPBR-3815: Enable s390x image builds

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -94,6 +94,9 @@ semaphore:
         options:
           - 'True'
           - 'False'
+cp_dockerfile:
+  s390x_docker_repos: ['confluentinc/cp-kafka-rest']
+  s390x_maven_modules: ['kafka-rest']
 code_artifact:
   enable: true
   package_paths:


### PR DESCRIPTION
Adds the `cp_dockerfile` block to `service.yml` so `cp-kafka-rest` is built for s390x, matching `8.2.x` and `master`.

```yaml
cp_dockerfile:
  s390x_docker_repos: ['confluentinc/cp-kafka-rest']
  s390x_maven_modules: ['kafka-rest']
```

The s390x config landed on `8.2.x` and `master` under CPBR-3661 but never on `8.3.x` (cut from master just before the change merged; `-s ours` merges don't carry content).

This PR contains `service.yml` changes only; files under `.semaphore/` will be auto-updated by triggering the cc-service-bot workflow.