### PR TITLE
DP-18712: fetch a repo-scoped DockerHub token in the promote prologue

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -42,8 +42,8 @@ global_job_config:
       - export BRANCH_TAG=$(echo $SEMAPHORE_GIT_BRANCH | tr / -)
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export PROMOTED_TAG_PREFIX="$CONFLUENT_VERSION-$IMAGE_REVISION"
-      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
-      - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+      - . get-auth-token dockerhub
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
       - export COMMUNITY_DOCKER_REPOS=""


### PR DESCRIPTION
## What
Replaces the org-wide DockerHub login in the cp-dockerfile **promote** prologue with a per-project, repo-scoped credential fetch, plus a `PACKAGING_BUILD_NUMBER` fix.

```diff
- if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
- docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+ if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+ . get-auth-token dockerhub
```

## Why
INC-9669 corrective action (DP-18712 / DP-18713): publishing jobs fetch a per-project, repo-scoped DockerHub token from SSM on demand instead of the org-wide static login. `get-auth-token` (on the CI agent image, ci-build-agent-infra#2626) is **sourced** so the login persists for later `docker push`. Also fixes the `PACKAGING_BUILD_NUMBER` default — the old line expanded `$PACKAGING_BUILD_NUMBER` before `export`, so an empty value ran `export ="latest"` and never set the default. Pre-verified: the edited region is byte-identical across the supported branches.

## Rollout
Base of the forward-merge rollout: **7.6.x** (the previous base branch is now end-of-support). After merge, `apply-pint-merge` (`FROM_BRANCH=7.6.x`) propagates it forward along the release line to master. Replaces the earlier PR #157.
